### PR TITLE
Accept escaped strings in replacement

### DIFF
--- a/parse/parse.go
+++ b/parse/parse.go
@@ -259,7 +259,7 @@ func (t *Tree) parseReplaceFunc(name string) (Node, error) {
 	}
 
 	{
-		param, err := t.parseParam(acceptNotClosing, scanIdent)
+		param, err := t.parseParam(acceptNotClosing, scanIdent|scanEscape)
 		if err != nil {
 			return nil, err
 		}

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -329,6 +329,36 @@ var tests = []struct {
 			},
 		},
 	},
+	{
+		Text: `${string/position/\/length}`,
+		Node: &FuncNode{
+			Param: "string",
+			Name:  "/",
+			Args: []Node{
+				&TextNode{
+					Value: "position",
+				},
+				&TextNode{
+					Value: "/length",
+				},
+			},
+		},
+	},
+	{
+		Text: `${string/position/\/length\\}`,
+		Node: &FuncNode{
+			Param: "string",
+			Name:  "/",
+			Args: []Node{
+				&TextNode{
+					Value: "position",
+				},
+				&TextNode{
+					Value: "/length\\",
+				},
+			},
+		},
+	},
 
 	// functions in functions
 	{


### PR DESCRIPTION
This PR adds support for escaped strings in the replacement-argument.
I came across this when trying to replace `-` in a variable with `/`, which would always lead to either `bad substitution` or `\/` in the output.