### PR TITLE
support dash in variable names

### DIFF
--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -42,6 +42,14 @@ var tests = []struct {
 		Text: "${string}",
 		Node: &FuncNode{Param: "string"},
 	},
+	{
+		Text: "${string_A}",
+		Node: &FuncNode{Param: "string_A"},
+	},
+	{
+		Text: "${string_A-b}",
+		Node: &FuncNode{Param: "string_A-b"},
+	},
 
 	//
 	// text transform functions

--- a/parse/scan.go
+++ b/parse/scan.go
@@ -206,7 +206,7 @@ func acceptRune(r rune, i int) bool {
 }
 
 func acceptIdent(r rune, i int) bool {
-	return unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_'
+	return unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' || r == '-'
 }
 
 func acceptColon(r rune, i int) bool {


### PR DESCRIPTION
I need that feature in a project to parse some IntelliJ env var  `_INTELLIJ_KARMA_INTERNAL_PARAMETER_user-config`.

I am not familiar with the details of the standard, but the following statement does at least proof the validity of the request.

```shell
env string_A-b=c env|grep 'A-b'
```
outputs 
```shell
string_A-b=c
```
According to http://wiki.bash-hackers.org/syntax/pattern the dash has some special meaning in **bracket expressions**, so I am not sure about my implementation.
I did not dig very deep into the complexity of the envsubst code.