### PR TITLE
Fix substr function if length is too high

### DIFF
--- a/funcs.go
+++ b/funcs.go
@@ -90,8 +90,8 @@ func toSubstr(s string, args ...string) string {
 
 	if pos+length >= len(s) {
 		// if the position exceeds the length of the
-		// string an empty string is returned
-		return ""
+		// string just return the rest of it like bash
+		return s[pos:]
 	}
 
 	return s[pos : pos+length]

--- a/funcs_test.go
+++ b/funcs_test.go
@@ -60,3 +60,25 @@ func Test_default(t *testing.T) {
 		t.Errorf("Expect default function uses default value, when variable empty")
 	}
 }
+
+func Test_substr(t *testing.T) {
+	got, want := toSubstr("123456789123456789", "0", "8"), "12345678"
+	if got != want {
+		t.Errorf("Expect substr function to cut from begining to length")
+	}
+
+	got, want = toSubstr("123456789123456789", "1", "8"), "23456789"
+	if got != want {
+		t.Errorf("Expect substr function to cut from offset to length")
+	}
+
+	got, want = toSubstr("123456789123456789", "9"), "123456789"
+	if got != want {
+		t.Errorf("Expect substr function to cut beginnging with offset")
+	}
+
+	got, want = toSubstr("123456789123456789", "9", "50"), "123456789"
+	if got != want {
+		t.Errorf("Expect substr function to ignore length if out of bound")
+	}
+}


### PR DESCRIPTION
With this fix the substr function behaves more like the bash
functionality, if the string is only 5 chars long and you call `${var:0:8}` it resulted in an empty string, now it correctly returns the 5 chars. Besides that I have also added some basic tests to make sure it behaves correctly.

Fixes #11