### PR TITLE
add envsubst cli command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+/envsubst
 coverage.out

--- a/cmd/envsubst/main.go
+++ b/cmd/envsubst/main.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"bufio"
+	"os"
+	"log"
+	"fmt"
+
+	"github.com/drone/envsubst"
+)
+
+func main() {
+	stdin := bufio.NewScanner(os.Stdin)
+	stdout := bufio.NewWriter(os.Stdout)
+
+	for stdin.Scan() {
+		line, err := envsubst.EvalEnv(stdin.Text())
+		if err != nil {
+			log.Fatalf("Error while envsubst: %v", err)
+		}
+		_, err = fmt.Fprintln(stdout, line)
+		if err != nil {
+			log.Fatalf("Error while writing to stdout: %v", err)
+		}
+		stdout.Flush()
+	}
+}
+


### PR DESCRIPTION
This would add a small cli command to use envsubst on stdin and write to stdout.

Its more or less a much more powerful replacement for gettext's envsubst.