### PR TITLE
Fix nil panic in toSubstr

### DIFF
--- a/funcs.go
+++ b/funcs.go
@@ -101,9 +101,14 @@ func toSubstr(s string, args ...string) string {
 	}
 
 	if pos+length >= len(s) {
+		if pos < len(s) {
+			// if the position exceeds the length of the
+			// string just return the rest of it like bash
+			return s[pos:]
+		}
 		// if the position exceeds the length of the
-		// string just return the rest of it like bash
-		return s[pos:]
+		// string an empty string is returned
+		return ""
 	}
 
 	return s[pos : pos+length]

--- a/funcs_test.go
+++ b/funcs_test.go
@@ -91,4 +91,9 @@ func Test_substr(t *testing.T) {
 	if got != want {
 		t.Errorf("Expect substr function to cut from the beginning to length for negative offsets exceeding string length")
 	}
+	
+	got, want = toSubstr("12345678", "9", "1"), ""
+	if got != want {
+		t.Errorf("Expect substr function to cut entire string if pos is itself out of bound")
+	}
 }


### PR DESCRIPTION
pos < len(s) needs to be checked in ${FOO:pos:len} just like it is checked in ${FOO:pos}.
Unit test for ${FOO:pos:len} when pos > len(s) the string of ${FOO}