### PR TITLE
Fix default not used Eval test

### DIFF
--- a/eval_test.go
+++ b/eval_test.go
@@ -62,7 +62,7 @@ func TestExpand(t *testing.T) {
 		// default not used
 		{
 			params: map[string]string{"var": "abc"},
-			input:  "${var=abc}",
+			input:  "${var=xyz}",
 			output: "abc",
 		},
 		// default used


### PR DESCRIPTION
This test case tests that the default is not used but rather the value from the params is used. 
Just changing the default value to be different from the params to make the test clear.