### PR TITLE
Parse default variables

### DIFF
--- a/eval_test.go
+++ b/eval_test.go
@@ -72,6 +72,21 @@ func TestExpand(t *testing.T) {
 			output: "xyz",
 		},
 		{
+			params: map[string]string{"default_var": "foo"},
+			input:  "something ${var=${default_var}}",
+			output: "something foo",
+		},
+		{
+			params: map[string]string{"default_var": "foo1"},
+			input:  `foo: ${var=${default_var}-suffix}`,
+			output: "foo: foo1-suffix",
+		},
+		{
+			params: map[string]string{"default_var": "foo1"},
+			input:  `foo: ${var=prefix${default_var}-suffix}`,
+			output: "foo: prefixfoo1-suffix",
+		},
+		{
 			params: map[string]string{},
 			input:  "${var:=xyz}",
 			output: "xyz",
@@ -161,6 +176,11 @@ func TestExpand(t *testing.T) {
 			params: map[string]string{"var01": "abcdEFGH28ij"},
 			input:  "some text ${var01}$${var$${var01}$var01${var01}",
 			output: "some text abcdEFGH28ij${var${var01}$var01abcdEFGH28ij",
+		},
+		{
+			params: map[string]string{"default_var": "foo"},
+			input:  "something $${var=${default_var}}",
+			output: "something ${var=foo}",
 		},
 		// some common escaping use cases
 		{

--- a/funcs.go
+++ b/funcs.go
@@ -50,10 +50,11 @@ func toUpperFirst(s string, args ...string) string {
 }
 
 // toDefault returns a copy of the string s if not empty, else
-// returns a copy of the first string argument.
+// returns a concatenation of the args without a separator.
 func toDefault(s string, args ...string) string {
-	if len(s) == 0 && len(args) == 1 {
-		s = args[0]
+	if len(s) == 0 && len(args) > 0 {
+		// don't use any separator
+		s = strings.Join(args, "")
 	}
 	return s
 }

--- a/funcs_test.go
+++ b/funcs_test.go
@@ -57,7 +57,12 @@ func Test_default(t *testing.T) {
 
 	got, want = toDefault("", "Hola Mundo"), "Hola Mundo"
 	if got != want {
-		t.Errorf("Expect default function uses default value, when variable empty")
+		t.Errorf("Expect default function uses default value, when variable empty. Got %s, Want %s", got, want)
+	}
+
+	got, want = toDefault("", "Hola Mundo", "-Bonjour le monde", "-Halló heimur"), "Hola Mundo-Bonjour le monde-Halló heimur"
+	if got != want {
+		t.Errorf("Expect default function to use concatenated args when variable empty. Got %s, Want %s", got, want)
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/drone/envsubst
 
 require github.com/google/go-cmp v0.2.0
+
+go 1.13

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -1,6 +1,8 @@
 package parse
 
-import "errors"
+import (
+	"errors"
+)
 
 // ErrBadSubstitution represents a substitution parsing error.
 var ErrBadSubstitution = errors.New("bad substitution")
@@ -116,6 +118,10 @@ func (t *Tree) parseParam(accept acceptFunc, mode byte) (Node, error) {
 	case tokenLbrack:
 		return t.parseFunc()
 	case tokenIdent:
+		return newTextNode(
+			t.scanner.string(),
+		), nil
+	case tokenRbrack:
 		return newTextNode(
 			t.scanner.string(),
 		), nil
@@ -293,18 +299,20 @@ func (t *Tree) parseDefaultFunc(name string) (Node, error) {
 		return nil, ErrBadSubstitution
 	}
 
-	// scan arg[1]
-	{
+	// loop through all possible runes in default param
+	for {
+		// this acts as the break condition. Peek to see if we reached the end
+		switch t.scanner.peek() {
+		case '}':
+			return node, t.consumeRbrack()
+		}
 		param, err := t.parseParam(acceptNotClosing, scanIdent)
 		if err != nil {
 			return nil, err
 		}
 
-		// param.Value = t.scanner.string()
 		node.Args = append(node.Args, param)
 	}
-
-	return node, t.consumeRbrack()
 }
 
 // parses the ${param,} string function

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -415,6 +415,52 @@ var tests = []struct {
 		},
 	},
 	{
+		Text: "${string=prefix-${var}}",
+		Node: &FuncNode{
+			Param: "string",
+			Name:  "=",
+			Args: []Node{
+				&TextNode{Value: "prefix-"},
+				&FuncNode{Param: "var"},
+			},
+		},
+	},
+	{
+		Text: "${string=${var}-suffix}",
+		Node: &FuncNode{
+			Param: "string",
+			Name:  "=",
+			Args: []Node{
+				&FuncNode{Param: "var"},
+				&TextNode{Value: "-suffix"},
+			},
+		},
+	},
+	{
+		Text: "${string=prefix-${var}-suffix}",
+		Node: &FuncNode{
+			Param: "string",
+			Name:  "=",
+			Args: []Node{
+				&TextNode{Value: "prefix-"},
+				&FuncNode{Param: "var"},
+				&TextNode{Value: "-suffix"},
+			},
+		},
+	},
+	{
+		Text: "${string=prefix${var} suffix}",
+		Node: &FuncNode{
+			Param: "string",
+			Name:  "=",
+			Args: []Node{
+				&TextNode{Value: "prefix"},
+				&FuncNode{Param: "var"},
+				&TextNode{Value: " suffix"},
+			},
+		},
+	},
+	{
 		Text: "${string//${stringy}/${stringz}}",
 		Node: &FuncNode{
 			Param: "string",
@@ -429,6 +475,7 @@ var tests = []struct {
 
 func TestParse(t *testing.T) {
 	for _, test := range tests {
+		t.Log(test.Text)
 		got, err := Parse(test.Text)
 		if err != nil {
 			t.Error(err)


### PR DESCRIPTION
Parse variables that are defined in default functions. For example,
${var=prefix-${default_var}-suffix}.

Fixes #21 