### PR TITLE
Escapes outside of variable substitution

### DIFF
--- a/cmd/envsubst/main.go
+++ b/cmd/envsubst/main.go
@@ -2,11 +2,11 @@ package main
 
 import (
 	"bufio"
-	"os"
-	"log"
 	"fmt"
+	"log"
+	"os"
 
-	"github.com/drone/envsubst"
+	"github.com/drone/envsubst/v2"
 )
 
 func main() {

--- a/eval_test.go
+++ b/eval_test.go
@@ -193,6 +193,12 @@ func TestExpand(t *testing.T) {
 			input:  `${stringZ//\//-}`,
 			output: "foo-bar-baz",
 		},
+		// escape outside of expansion shouldn't be processed
+		{
+			params: map[string]string{"default_var": "foo"},
+			input:  "\\\\something ${var=${default_var}}",
+			output: "\\\\something foo",
+		},
 		// substitute with a blank string
 		{
 			params: map[string]string{"stringZ": "foo.bar"},

--- a/eval_test.go
+++ b/eval_test.go
@@ -202,19 +202,21 @@ func TestExpand(t *testing.T) {
 	}
 
 	for _, expr := range expressions {
-		t.Logf(expr.input)
-		output, err := Eval(expr.input, func(s string) string {
-			return expr.params[s]
-		})
-		if err != nil {
-			t.Errorf("Want %q expanded but got error %q", expr.input, err)
-		}
+		t.Run(expr.input, func(t *testing.T) {
+			t.Logf(expr.input)
+			output, err := Eval(expr.input, func(s string) string {
+				return expr.params[s]
+			})
+			if err != nil {
+				t.Errorf("Want %q expanded but got error %q", expr.input, err)
+			}
 
-		if output != expr.output {
-			t.Errorf("Want %q expanded to %q, got %q",
-				expr.input,
-				expr.output,
-				output)
-		}
+			if output != expr.output {
+				t.Errorf("Want %q expanded to %q, got %q",
+					expr.input,
+					expr.output,
+					output)
+			}
+		})
 	}
 }

--- a/funcs.go
+++ b/funcs.go
@@ -6,7 +6,7 @@ import (
 	"unicode"
 	"unicode/utf8"
 
-	"github.com/drone/envsubst/path"
+	"github.com/drone/envsubst/v2/path"
 )
 
 // defines a parameter substitution function.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/drone/envsubst
+module github.com/drone/envsubst/v2
 
 require github.com/google/go-cmp v0.2.0
 

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -50,6 +50,7 @@ func (t *Tree) Parse(buf string) (tree *Tree, err error) {
 func (t *Tree) parseAny() (Node, error) {
 	t.scanner.accept = acceptRune
 	t.scanner.mode = scanIdent | scanLbrack | scanEscape
+	t.scanner.escapeChars = dollar
 
 	switch t.scanner.scan() {
 	case tokenIdent:
@@ -86,6 +87,8 @@ func (t *Tree) parseAny() (Node, error) {
 }
 
 func (t *Tree) parseFunc() (Node, error) {
+	// Turn on all escape characters
+	t.scanner.escapeChars = escapeAll
 	switch t.scanner.peek() {
 	case '#':
 		return t.parseLenFunc()

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -476,13 +476,15 @@ var tests = []struct {
 func TestParse(t *testing.T) {
 	for _, test := range tests {
 		t.Log(test.Text)
-		got, err := Parse(test.Text)
-		if err != nil {
-			t.Error(err)
-		}
+		t.Run(test.Text, func(t *testing.T) {
+			got, err := Parse(test.Text)
+			if err != nil {
+				t.Error(err)
+			}
 
-		if diff := cmp.Diff(test.Node, got.Root); diff != "" {
-			t.Errorf(diff)
-		}
+			if diff := cmp.Diff(test.Node, got.Root); diff != "" {
+				t.Errorf(diff)
+			}
+		})
 	}
 }

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -34,6 +34,10 @@ var tests = []struct {
 		Text: "$$string",
 		Node: &TextNode{Value: "$string"}, // should not escape double dollar
 	},
+	{
+		Text: `\\.\pipe\pipename`,
+		Node: &TextNode{Value: `\\.\pipe\pipename`},
+	},
 
 	//
 	// variable only
@@ -297,6 +301,28 @@ var tests = []struct {
 			},
 		},
 	},
+	// text before and after function with \\ outside of function
+	{
+		Text: `\\ hello ${#string} world \\`,
+		Node: &ListNode{
+			Nodes: []Node{
+				&TextNode{
+					Value: `\\ hello `,
+				},
+				&ListNode{
+					Nodes: []Node{
+						&FuncNode{
+							Param: "string",
+							Name:  "#",
+						},
+						&TextNode{
+							Value: ` world \\`,
+						},
+					},
+				},
+			},
+		},
+	},
 
 	// escaped function arguments
 	{
@@ -355,6 +381,21 @@ var tests = []struct {
 				},
 				&TextNode{
 					Value: "/length\\",
+				},
+			},
+		},
+	},
+	{
+		Text: `${string/position/\/leng\\th}`,
+		Node: &FuncNode{
+			Param: "string",
+			Name:  "/",
+			Args: []Node{
+				&TextNode{
+					Value: "position",
+				},
+				&TextNode{
+					Value: "/leng\\th",
 				},
 			},
 		},

--- a/template.go
+++ b/template.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"io/ioutil"
 
-	"github.com/drone/envsubst/parse"
+	"github.com/drone/envsubst/v2/parse"
 )
 
 // state represents the state of template execution. It is not part of the


### PR DESCRIPTION
This demonstrates #26:

```
eval_test.go:211: \\something ${var=${default_var}}
eval_test.go:220: Want "\\\\something ${var=${default_var}}" expanded to "\\\\something foo", got "\\something foo" 
```

Once get confirmation on behavior expected can update.