### PR TITLE
Document supported functions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,7 @@ Includes support for bash string replacement functions.
 | `${#var}`                     | String length of `$var`
 | `${var:n}`                    | Offset `$var` `n` characters from start
 | `${var: -n}`                  | Offset `$var` `n` characters from end
-| `${var:n:len}`                | Offset `$var` `n` characters of `len` length
+| `${var:n:len}`                | Offset `$var` `n` characters with max length of `len`
 | `${var#pattern}`              | Strip shortest `pattern` match from start
 | `${var##pattern}`             | Strip longest `pattern` match from start
 | `${var%pattern}`              | Strip shortest `pattern` match from end

--- a/readme.md
+++ b/readme.md
@@ -9,24 +9,30 @@ Includes support for bash string replacement functions.
 
 ## Supported Functions
 
-* `${var^}`
-* `${var^^}`
-* `${var,}`
-* `${var,,}`
-* `${var:position}`
-* `${var:position:length}`
-* `${var#substring}`
-* `${var##substring}`
-* `${var%substring}`
-* `${var%%substring}`
-* `${var/substring/replacement}`
-* `${var//substring/replacement}`
-* `${var/#substring/replacement}`
-* `${var/%substring/replacement}`
-* `${#var}`
-* `${var=default}`
-* `${var:=default}`
-* `${var:-default}`
+| __Expression__                | __Meaning__                                                     |
+| -----------------             | --------------                                                  |
+| `${var}`                      | Value of var
+| `${var-${DEFAULT}}`           | If `$var` is not set, evaluate expression as `${DEFAULT}`
+| `${var:-${DEFAULT}}`          | If `$var` is not set or is empty, evaluate expression as `${DEFAULT}`
+| `${var=${DEFAULT}}`           | If `$var` is not set, evaluate expression as `${DEFAULT}`
+| `${var:=${DEFAULT}}`          | If `$var` is not set or is empty, evaluate expression as `${DEFAULT}`
+| `$$var`                       | Escape expressions. Result will be the string `$var`
+| `${var^}`                     | Uppercase first character of `$var`
+| `${var^^}`                    | Uppercase all characters in `$var`
+| `${var,}`                     | Lowercase first character of `$var`
+| `${var,,}`                    | Lowercase all characters in `$var`
+| `${#var}`                     | String length of `$var`
+| `${var:n}`                    | Offset `$var` `n` characters from the left
+| `${var: -n}`                  | Offset `$var` `n` characters from the right
+| `${var:n:len}`                | Offset `$var` `n` characters of `len` length
+| `${var#pattern}`              | Strip shortest `pattern` match from start
+| `${var##pattern}`             | Strip longest `pattern` match from start
+| `${var%pattern}`              | Strip shortest `pattern` match from end
+| `${var%%pattern}`             | Strip longest `pattern` match from end
+| `${var/pattern/replacement}`  | Replace as few `pattern` matches as possible with `replacement`
+| `${var//pattern/replacement}` | Replace as many `pattern` matches as possible with `replacement`
+| `${var/#pattern/replacement}` | Replace `pattern` match with `replacement` from `$var` start
+| `${var/%pattern/replacement}` | Replace `pattern` match with `replacement` from `$var` end
 
 ## Unsupported Functions
 

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ Includes support for bash string replacement functions.
 
 | __Expression__                | __Meaning__                                                     |
 | -----------------             | --------------                                                  |
-| `${var}`                      | Value of var
+| `${var}`                      | Value of `$var`
 | `${var-${DEFAULT}}`           | If `$var` is not set, evaluate expression as `${DEFAULT}`
 | `${var:-${DEFAULT}}`          | If `$var` is not set or is empty, evaluate expression as `${DEFAULT}`
 | `${var=${DEFAULT}}`           | If `$var` is not set, evaluate expression as `${DEFAULT}`
@@ -22,8 +22,8 @@ Includes support for bash string replacement functions.
 | `${var,}`                     | Lowercase first character of `$var`
 | `${var,,}`                    | Lowercase all characters in `$var`
 | `${#var}`                     | String length of `$var`
-| `${var:n}`                    | Offset `$var` `n` characters from the left
-| `${var: -n}`                  | Offset `$var` `n` characters from the right
+| `${var:n}`                    | Offset `$var` `n` characters from start
+| `${var: -n}`                  | Offset `$var` `n` characters from end
 | `${var:n:len}`                | Offset `$var` `n` characters of `len` length
 | `${var#pattern}`              | Strip shortest `pattern` match from start
 | `${var##pattern}`             | Strip longest `pattern` match from start


### PR DESCRIPTION
I've added some "cheatsheet" explanations to the provided expressions from a combination of these sources for use as a quick reference:
https://www.gnu.org/software/bash/manual/html_node/Pattern-Matching.html
https://wiki.bash-hackers.org/syntax/pe#case_modification

* renamed `substring` to `pattern` since pattern matching (*, ?, [^a-z]) work in envsubst
* renamed `position` to `n` 🤷 