### PR TITLE
add --strict.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3,6 +3,6 @@ name: default
 
 steps:
 - name: build
-  image: golang:1.11
+  image: golang:1.19
   commands:
   - go test -v ./...

--- a/cmd/envsubst/main.go
+++ b/cmd/envsubst/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"flag"
 	"fmt"
 	"log"
 	"os"
@@ -9,12 +10,14 @@ import (
 	"github.com/drone/envsubst/v2"
 )
 
+var flagStrict bool = false
+
 func main() {
+	flag.Parse()
 	stdin := bufio.NewScanner(os.Stdin)
 	stdout := bufio.NewWriter(os.Stdout)
-
 	for stdin.Scan() {
-		line, err := envsubst.EvalEnv(stdin.Text())
+		line, err := envsubst.EvalEnv(stdin.Text(), flagStrict)
 		if err != nil {
 			log.Fatalf("Error while envsubst: %v", err)
 		}
@@ -26,3 +29,6 @@ func main() {
 	}
 }
 
+func init() {
+	flag.BoolVar(&flagStrict, "strict", false, "fail if variable is undefined.")
+}

--- a/eval.go
+++ b/eval.go
@@ -3,7 +3,7 @@ package envsubst
 import "os"
 
 // Eval replaces ${var} in the string based on the mapping function.
-func Eval(s string, mapping func(string) string) (string, error) {
+func Eval(s string, mapping func(string) (string, bool)) (string, error) {
 	t, err := Parse(s)
 	if err != nil {
 		return s, err
@@ -14,6 +14,14 @@ func Eval(s string, mapping func(string) string) (string, error) {
 // EvalEnv replaces ${var} in the string according to the values of the
 // current environment variables. References to undefined variables are
 // replaced by the empty string.
-func EvalEnv(s string) (string, error) {
-	return Eval(s, os.Getenv)
+func EvalEnv(s string, strict bool) (string, error) {
+	mapping := Getenv
+	if strict{
+		mapping = os.LookupEnv
+	}
+	return Eval(s, mapping)
+}
+
+func Getenv(s string) (string, bool) {
+	return os.Getenv(s), true
 }

--- a/readme.md
+++ b/readme.md
@@ -34,6 +34,10 @@ Includes support for bash string replacement functions.
 
 For a deeper reference, see [bash-hackers](https://wiki.bash-hackers.org/syntax/pe#case_modification) or [gnu pattern matching](https://www.gnu.org/software/bash/manual/html_node/Pattern-Matching.html).
 
+## Strict mode
+
+Use `--strict` if you want `envsubst` to fail, if an undefined variable gets accessed.
+
 ## Unsupported Functions
 
 * `${var-default}`


### PR DESCRIPTION
This PR adds `--strict`, so that envsubst fails if it access undefined variables.